### PR TITLE
Change timing of calling `didDismiss`

### DIFF
--- a/Spotlight/Sources/SpotlightViewController.swift
+++ b/Spotlight/Sources/SpotlightViewController.swift
@@ -149,7 +149,8 @@ extension SpotlightViewController {
     }
 
     func dismissSpotlight() {
-        dismiss(animated: true, completion: nil)
-        delegate?.didDismiss()
+        dismiss(animated: true) {
+            self.delegate?.didDismiss()
+        }
     }
 }


### PR DESCRIPTION
I think it's better to call didDismiss delegate function after the dismissing animation has finished.

This makes it easy to make another screen transition or get presentedController in the callback.


